### PR TITLE
20251007 - Fixes a bug on the definition of join2

### DIFF
--- a/kafi/streams/topologynode.py
+++ b/kafi/streams/topologynode.py
@@ -1,18 +1,27 @@
-from pydbsp.indexed_zset.functions.bilinear import join_with_index
-from pydbsp.indexed_zset.operators.linear import LiftedIndex, LiftedLiftedIndex
-from pydbsp.indexed_zset.operators.bilinear import DeltaLiftedDeltaLiftedSortMergeJoin
-from pydbsp.stream import step_until_fixpoint_and_return, StreamHandle
-from pydbsp.stream.functions.linear import stream_elimination
-from pydbsp.zset.operators.linear import LiftedSelect, LiftedProject
-from pydbsp.stream.operators.linear import LiftedStreamIntroduction
-from pydbsp.stream.operators.bilinear import Incrementalize2
-
 import json
+
+from pydbsp.indexed_zset.functions.bilinear import join_with_index
+from pydbsp.indexed_zset.operators.bilinear import DeltaLiftedDeltaLiftedSortMergeJoin
+from pydbsp.indexed_zset.operators.linear import LiftedIndex, LiftedLiftedIndex
+from pydbsp.stream import step_until_fixpoint_and_return
+from pydbsp.stream.operators.bilinear import Incrementalize2
+from pydbsp.stream.operators.linear import (
+    LiftedStreamElimination,
+    LiftedStreamIntroduction,
+)
+from pydbsp.zset.operators.linear import LiftedProject, LiftedSelect
 
 #
 
+
 class TopologyNode:
-    def __init__(self, name_str="", output_handle_function=lambda: None, step_function=lambda: None, daughter_topologyNode_list=[]):
+    def __init__(
+        self,
+        name_str="",
+        output_handle_function=lambda: None,
+        step_function=lambda: None,
+        daughter_topologyNode_list=[],
+    ):
         self._name_str = name_str
         self._output_handle_function = output_handle_function
         self._step_function = step_function
@@ -24,14 +33,18 @@ class TopologyNode:
         def map_function1(message_json_str):
             message_dict = json.loads(message_json_str)
             return json.dumps(map_function(message_dict))
+
         #
         liftedProject = LiftedProject(self._output_handle_function(), map_function1)
+
         #
         def output_handle_function():
             return liftedProject.output_handle()
+
         #
         def step_function():
             liftedProject.step()
+
         #
         return TopologyNode("map_op", output_handle_function, step_function, [self])
 
@@ -39,14 +52,18 @@ class TopologyNode:
         def filter_function1(message_json_str):
             message_dict = json.loads(message_json_str)
             return filter_function(message_dict)
+
         #
         liftedSelect = LiftedSelect(self._output_handle_function(), filter_function1)
+
         #
         def output_handle_function():
             return liftedSelect.output_handle()
+
         #
         def step_function():
             liftedSelect.step()
+
         #
         return TopologyNode("filter_op", output_handle_function, step_function, [self])
 
@@ -54,11 +71,15 @@ class TopologyNode:
         def on_function1(message_json_str):
             message_dict = json.loads(message_json_str)
             return json.dumps(on_function(message_dict))
+
         #
         def projection_function1(key, left_message_json_str, right_message_json_str):
             left_message_dict = json.loads(left_message_json_str)
             right_message_dict = json.loads(right_message_json_str)
-            return json.dumps(projection_function(key, left_message_dict, right_message_dict))
+            return json.dumps(
+                projection_function(key, left_message_dict, right_message_dict)
+            )
+
         #
         index_function = lambda x: on_function1(x)
         left_index = LiftedIndex(self._output_handle_function(), index_function)
@@ -67,27 +88,36 @@ class TopologyNode:
             left_index.output_handle(),
             right_index.output_handle(),
             lambda l, r: join_with_index(l, r, projection_function1),
-            self.group
+            self.group,
         )
+
         def output_handle_function():
             return join_op.output_handle()
+
         #
         def step_function():
             left_index.step()
             right_index.step()
             join_op.step()
+
         #
-        return TopologyNode("join_op", output_handle_function, step_function, [self, other])
+        return TopologyNode(
+            "join_op", output_handle_function, step_function, [self, other]
+        )
 
     def join2(self, other, on_function, projection_function):
         def on_function1(message_json_str):
             message_dict = json.loads(message_json_str)
             return json.dumps(on_function(message_dict))
+
         #
         def projection_function1(key, left_message_json_str, right_message_json_str):
             left_message_dict = json.loads(left_message_json_str)
             right_message_dict = json.loads(right_message_json_str)
-            return json.dumps(projection_function(key, left_message_dict, right_message_dict))
+            return json.dumps(
+                projection_function(key, left_message_dict, right_message_dict)
+            )
+
         #
         l1 = LiftedStreamIntroduction(self._output_handle_function())
         r1 = LiftedStreamIntroduction(other._output_handle_function())
@@ -97,39 +127,51 @@ class TopologyNode:
         r2 = LiftedLiftedIndex(r1.output_handle(), index_function)
         #
         deltaLiftedDeltaLiftedSortMergeJoin = DeltaLiftedDeltaLiftedSortMergeJoin(
-            l2.output_handle(),
-            r2.output_handle(),
-            projection_function1)
+            l2.output_handle(), r2.output_handle(), projection_function1
+        )
+
+        output_node = LiftedStreamElimination(
+            deltaLiftedDeltaLiftedSortMergeJoin.output_handle()
+        )
+
         #
         def output_handle_function():
-            return StreamHandle(lambda: stream_elimination(deltaLiftedDeltaLiftedSortMergeJoin.output_handle().get()))
+            return output_node.output_handle()
+
         #
         def step_function():
             l1.step()
             r1.step()
             l2.step()
             r2.step()
-            # deltaLiftedDeltaLiftedSortMergeJoin.step()
-            step_until_fixpoint_and_return(deltaLiftedDeltaLiftedSortMergeJoin)
+            deltaLiftedDeltaLiftedSortMergeJoin.step()
+            step_until_fixpoint_and_return(output_node)
+
         #
-        return TopologyNode("join2_op", output_handle_function, step_function, [self, other])
+        return TopologyNode(
+            "join2_op", output_handle_function, step_function, [self, other]
+        )
 
     def peek(self, peek_function):
         def peek_function1(message_json_str):
             message_dict = json.loads(message_json_str)
             peek_function(message_dict)
             return message_json_str
+
         #
         liftedProject = LiftedProject(self._output_handle_function(), peek_function1)
+
         #
         def output_handle_function():
             return liftedProject.output_handle()
+
         #
         def step_function():
             liftedProject.step()
+
         #
         return TopologyNode("peek_op", output_handle_function, step_function, [self])
-    
+
     #
 
     def step(self):
@@ -138,13 +180,14 @@ class TopologyNode:
             for daughter in topologyNode.daughters():
                 traverse(daughter, stack)
             return stack
+
         #
         stack = traverse(self, [])
         #
         while stack:
             topologyNode = stack.pop()
             topologyNode._step_function()
-    
+
     #
 
     def name(self):
@@ -157,7 +200,7 @@ class TopologyNode:
         return self._step_function
 
     def daughters(self):
-        return self._daughter_topologyNode_list    
+        return self._daughter_topologyNode_list
 
     #
 
@@ -174,15 +217,18 @@ class TopologyNode:
             case 1:
                 return f"{self._name_str}({self._daughter_topologyNode_list[0].topology()})"
             case 2:
-                return  f"{self._name_str}({self._daughter_topologyNode_list[0].topology()}, {self._daughter_topologyNode_list[1].topology()})"
+                return f"{self._name_str}({self._daughter_topologyNode_list[0].topology()}, {self._daughter_topologyNode_list[1].topology()})"
 
     def mermaid(self):
         def collect_nodes(topologyNode, name_str_set, edge_str_list):
             name_str_set.add(topologyNode.name())
             #
             for daughter_topologyNode in topologyNode.daughters():
-                edge_str_list.append(f"{daughter_topologyNode.name()} --> {topologyNode.name()}")
+                edge_str_list.append(
+                    f"{daughter_topologyNode.name()} --> {topologyNode.name()}"
+                )
                 collect_nodes(daughter_topologyNode, name_str_set, edge_str_list)
+
         #
         node_str_set = set()
         edge_str_list = []

--- a/test_topologynode.py
+++ b/test_topologynode.py
@@ -1,39 +1,52 @@
 from kafi.streams.streams import *
 
+
 def map_function(message_dict):
     message_dict["value"]["name"] = message_dict["value"]["name"] + "_abc"
     return message_dict
 
+
 def proj_function(_, left_message_dict, right_message_dict):
     left_message_dict["value"].update(right_message_dict["value"])
     return left_message_dict
+
 
 def setup():
     employees_source_topologyNode = source("employees_source")
     salaries_source_topologyNode = source("salaries_source")
     #
     root_topologyNode = (
-        employees_source_topologyNode
-        .filter(lambda message_dict: message_dict["value"]["name"] != "mark")
-        .join(
+        employees_source_topologyNode.filter(
+            lambda message_dict: message_dict["value"]["name"] != "mark"
+        )
+        .join2(
             salaries_source_topologyNode,
             on_function=lambda message_dict: message_dict["key"],
-            projection_function=proj_function
+            projection_function=proj_function,
         )
         # .peek(print)
         .map(map_function)
     )
     #
-    return employees_source_topologyNode, salaries_source_topologyNode, root_topologyNode
+    return (
+        employees_source_topologyNode,
+        salaries_source_topologyNode,
+        root_topologyNode,
+    )
+
 
 employees_source_topologyNode, salaries_source_topologyNode, root_topologyNode = setup()
 
-employee_message_dict_list = [{"key": "0", "value": {"name": "kristjan"}},
-                            {"key": "1", "value": {"name": "mark"}},
-                            {"key": "2", "value": {"name": "mike"}}]
-salary_message_dict_list = [{"key": "2", "value": {"salary": 40000}},
-                            {"key": "0", "value": {"salary": 38750}},
-                            {"key": "1", "value": {"salary": 50000}}]
+employee_message_dict_list = [
+    {"key": "0", "value": {"name": "kristjan"}},
+    {"key": "1", "value": {"name": "mark"}},
+    {"key": "2", "value": {"name": "mike"}},
+]
+salary_message_dict_list = [
+    {"key": "2", "value": {"salary": 40000}},
+    {"key": "0", "value": {"salary": 38750}},
+    {"key": "1", "value": {"salary": 50000}},
+]
 
 employee_zset = message_dict_list_to_ZSet(employee_message_dict_list)
 salary_zset = message_dict_list_to_ZSet(salary_message_dict_list)


### PR DESCRIPTION
**The Problem**

`join` and `join2` should always have parity in the latest value of each of their streams assuming the latter has the stream elimination operator applied to it. 

**The Solution**

0. Connected the output of `DeltaLiftedDeltaLiftedSortMergeJoin` to a `LiftedStreamElimination` operator.
1. Fixed the definition of `join2`'s `output_handle_function` by simply returning `LiftedStreamElimination`'s `output_handle`.

The major problem here was that the previous definition of `output_handle_function`:
```
return StreamHandle(lambda: stream_elimination(deltaLiftedDeltaLiftedSortMergeJoin.output_handle().get()))
```

applied `stream_elimination` over the entire `deltaLiftedDeltaLiftedSortMergeJoin.output_handle` output (flattening a stream of streams into a stream), instead of over each stream of the stream of streams (flattening each stream of the stream of streams into a `ZSet`)